### PR TITLE
integrating slack channel

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -25,4 +25,6 @@ jobs:
       - name: Send notification to Slack
         uses: rtCamp/action-slack-notify@v2.1.0
         env:
-          SLACK_WEB
+          SLACK_WEBHOOK: ${{ secrets.SLACK_PUSH_WEBHOOK }}
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: 'A new push has been made to the repository!'

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,28 @@
+name: Notify Slack
+
+on:
+  pull_request:
+    types:
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - ready_for_review
+      - locked
+      - unlocked
+      - review_requested
+      - review_request_removed
+
+jobs:
+  slackNotification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Slack
+        uses: rtCamp/action-slack-notify@v2.1.0
+        env:
+          SLACK_WEB

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Send notification to Slack
         uses: rtCamp/action-slack-notify@v2.1.0
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_PUSH_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: 'GitHub Actions'
           SLACK_MESSAGE: 'A new push has been made to the repository!'

--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ docker exec -it 89d4f551353f /opt/kafka/bin/kafka-console-producer.sh --broker-l
 ```shell
 docker exec -it 89d4f551353f /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic my-topic --from-beginning
 ```
+
+
+slack: https://app.slack.com/client/T07D61D72RY/C07D5TQCS1H


### PR DESCRIPTION
To generate a Slack webhook, follow these steps:

- Visit Slack App Management.

- Create a New App:
Click on "Create New App."
Choose "From scratch."
Enter an app name and select your workspace.
Enable Incoming Webhooks:

- Navigate to the "Features" section and select "Incoming Webhooks."
Activate "Incoming Webhooks."
Create a Webhook URL:

- Click "Add New Webhook to Workspace."
Select a channel for the webhook and authorize.
Copy the generated webhook URL.
You can now use this webhook URL in your GitHub Actions workflow. For detailed instructions, refer to the Slack API documentation.


The webhook URL from Slack typically looks like this:

Copy code
`https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
T00000000: Represents the workspace identifier.
B00000000: Represents the webhook's identifier.
XXXXXXXXXXXXXXXXXXXXXXXX: Represents the secret part of the URL that ensures the webhook's security.